### PR TITLE
Added Dockerfile and entrypoint script for use with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:buster-slim
+
+RUN apt-get update && apt-get install -yq \
+    python3-pip \
+    python3-gdal
+
+RUN pip3 install \
+    osm-export-tool
+
+COPY bin/docker_entrypoint.sh /bin/docker_entrypoint.sh
+
+ENTRYPOINT [ "/bin/docker_entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ RUN apt-get update && apt-get install -yq \
     python3-pip \
     python3-gdal
 
-RUN pip3 install \
-    osm-export-tool
+COPY . /source/osm-export-tool-python
+
+RUN pip3 install /source/osm-export-tool-python
 
 COPY bin/docker_entrypoint.sh /bin/docker_entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ PyOsmium is used to read OSM files and GDAL/OGR is used to write GIS files, so t
 
 This library will not automatically install GDAL because it needs to match the version on your system. You will need to separately run `pip install GDAL==2.3.2` (change 2.3.2 to match `gdalinfo --version`)
 
+## Running with Docker
+
+If you want to avoid installing the right version of GDAL on your system you can run the program as a docker container instead.
+
+To build the docker image, use the following command.
+
+```
+docker build -t osm-export-tool .
+```
+
+To run the tool as a container, using your current directory as working directory, use the following command.
+
+```
+docker run -it --rm -v $(pwd):/work osm-export-tool INPUT_FILE.pbf OUTPUT_NAME
+```
+
 ## Example usage
 
 ```

--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p /work
+cd /work
+osm-export-tool "$@"


### PR DESCRIPTION
Addresses #10 

This adds a Dockerfile based on Debian Buster, which was a lot easier to work with in this case since the Ubuntu PPAs for GDAL are not set up for newer releases. Also the python bindings are readily available as an apt install.

Added some notes to the readme on how to build and run this.